### PR TITLE
separate losses

### DIFF
--- a/model.py
+++ b/model.py
@@ -11,9 +11,9 @@ import utils
 
 class Scribe(nn.Module):
     @argbind.bind(without_prefix=True)
-    def __init__(self, input_size=3, hidden_size=20, output_size=3):
+    def __init__(self, input_size=3, hidden_size=20, num_layers=1, output_size=3):
         super(Scribe, self).__init__()
-        self.rnn = nn.GRU(input_size=input_size, hidden_size=hidden_size, num_layers=1)
+        self.rnn = nn.GRU(input_size=input_size, hidden_size=hidden_size, num_layers=num_layers)
         self.linear = nn.Linear(in_features=hidden_size, out_features=output_size)
 
     def forward(self, strokes):
@@ -31,16 +31,26 @@ class Scribe(nn.Module):
         return next(self.parameters()).device
 
     @argbind.bind
-    def sample(self, batch_size=1, num_steps=100, bias=0.0):
+    def sample(self, batch_size=1, num_steps=100, bias=0.0, stddev=0.1):
         x = torch.zeros(1, batch_size, 3).to(self.device)
         hidden = None
         output = []
         for i in range(num_steps):
             x, hidden = self.step(x, hidden)
             output.append(x)
-        return torch.vstack(output)
+        output = torch.vstack(output)
+        zeros = torch.zeros(num_steps, batch_size, 2).to(self.device)
 
-
+        # Bias is weird now because we have a fixed stddev.  Instead of using bias, we could
+        # just adjust stddev.
+        #
+        # However, in the future, log-stddev will be part of the output of the model, and so it makes sense
+        # to apply bias independently.
+        std = torch.exp(torch.log(zeros + stddev) - bias)
+        noise = torch.normal(mean=zeros, std=std)
+        output[:, :, 1:3] += noise
+        output[:, :, 0:1] = torch.sigmoid(output[:, :, 0:1]) > torch.rand((num_steps, batch_size, 1)).to(self.device)
+        return output
 
 
 
@@ -50,6 +60,7 @@ def main(show_strokes=True, show_output=False, show_samples=False):
     dl = DataLoader(dataset, shuffle=True, batch_size=4, collate_fn=data.collate_fn)
     texts, texts_mask, strokes, strokes_mask = next(iter(dl))
 
+    # TODO: Apply mask to strokes
     model = Scribe()
 
     with torch.no_grad():

--- a/train_test.py
+++ b/train_test.py
@@ -1,0 +1,85 @@
+import math
+import unittest
+
+import torch
+
+from train import scribe_loss
+
+
+class TestTrain(unittest.TestCase):
+
+    def test_scribe_loss_penup_one_matches(self):
+        prediction = torch.tensor([[[1e5, 0, 0]]])
+        target = torch.tensor([[[1.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask)
+        torch.testing.assert_close(result, torch.tensor(0.0))
+
+    def test_scribe_loss_penup_zero_matches(self):
+        prediction = torch.tensor([[[-1e5, 0, 0]]])
+        target = torch.tensor([[[0.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask)
+        torch.testing.assert_close(result, torch.tensor(0.0))
+
+    def test_scribe_loss_penup_zero_nomatch(self):
+        prediction = torch.tensor([[[1e5, 0, 0]]])
+        target = torch.tensor([[[0.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask)
+        torch.testing.assert_close(result, torch.tensor(1e5/2))
+
+    def test_scribe_loss_penup_one_nomatch(self):
+        prediction = torch.tensor([[[-1e5, 0, 0]]])
+        target = torch.tensor([[[1.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask)
+        torch.testing.assert_close(result, torch.tensor(1e5/2))
+
+    def test_scribe_loss_coord_differ(self):
+        prediction = torch.tensor([[[1e5, 3, 4]]])
+        target = torch.tensor([[[1.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask)
+        torch.testing.assert_close(result, torch.tensor(25/2))
+
+    def test_scribe_loss_penup_equal_weighting(self):
+        prediction = torch.tensor([[[0.0, 3, 4]]])
+        target = torch.tensor([[[0.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask, penup_weighting=0.5)
+        expected = torch.tensor((-math.log(0.5)+25)/2)
+        torch.testing.assert_close(result, expected)
+
+    def test_scribe_loss_penup_nonequal_weighting(self):
+        prediction = torch.tensor([[[0.0, 3, 4]]])
+        target = torch.tensor([[[0.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask, penup_weighting=0.75)
+        expected = torch.tensor(3 * (-math.log(0.5))/ 4 + 25/4)
+        torch.testing.assert_close(result, expected)
+
+    def test_scribe_loss_without_mask(self):
+        prediction = torch.tensor([[[0.0, 3, 4], [0.0, 2, 3]]])
+        target = torch.tensor([[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1, 1]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask)
+        expected = torch.tensor((-2 * math.log(0.5) + 13 + 25)/4)
+        torch.testing.assert_close(result, expected)
+
+    def test_scribe_loss_with_mask(self):
+        prediction = torch.tensor([[[0.0, 3, 4], [0.0, 2, 3]]])
+        target = torch.tensor([[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]])
+        target_mask = torch.tensor([[1, 0]], dtype=torch.bool)
+
+        result = scribe_loss(prediction, target, target_mask)
+        expected = torch.tensor((-math.log(0.5) + 25)/2)
+        torch.testing.assert_close(result, expected)


### PR DESCRIPTION
Have separate penup and coordinate losses.

Former uses binary crossentropy while latter uses MSE error.

Here's a sample after training with:
`python train.py --device cuda --num_training_iterations 10000 --batch_size 256 --validation_percentage 0 --hidden_size 100 --num_layers=3  --device=cuda:0
`<img width="667" alt="image" src="https://user-images.githubusercontent.com/6276665/222546165-4bad6cec-b947-4460-a207-4f1efcd79b5a.png">
